### PR TITLE
Fix link to site in README by adding scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Halt and Catch Fire Syllabus
 
-Repo for [this site](bits.ashleyblewer.com/halt-and-catch-fire-syllabus/)
+Repo for [this site](https://bits.ashleyblewer.com/halt-and-catch-fire-syllabus/)
 
 ## License
 


### PR DESCRIPTION
...otherwise, it resolves to https://github.com/ablwr/halt-and-catch-fire-syllabus/blob/main/bits.ashleyblewer.com/halt-and-catch-fire-syllabus when accessed from the link displayed in the GitHub repo.