### PR TITLE
Update 04.md Le Guin Wayback link

### DIFF
--- a/_classes/04.md
+++ b/_classes/04.md
@@ -62,7 +62,7 @@ Computers allow us to forget about tangible objects, but they are still part of 
 <div class="readings" markdown="1">
 ## Readings
 
-- Ursula K. Le Guin, [A Rant About "Technology"](http://www.ursulakleguinarchive.com/Note-Technology.html)
+- Ursula K. Le Guin, [A Rant About "Technology"](https://web.archive.org/web/20230602032121/http://www.ursulakleguinarchive.com/Note-Technology.html)
 - Miriam  Posner, [See No Evil](https://logicmag.io/scale/see-no-evil/), Logic mag, Issue 4 (April 2018)
 - Ingrid Burrington, [Light Industry: Toxic Waste and Pastoral Capitalism](https://www.e-flux.com/journal/74/59781/light-industry-toxic-waste-and-pastoral-capitalism/), e-flux Journal #74 (June 2016)
 - Sharon Begley with John Carey, [Toxic Trouble in Silicon Valley](https://icrt.co/wp-content/uploads/2019/12/1984_5_7-Toxic-Trouble-in-Silicon-Valley-Newsweek.pdf) (May 1984)


### PR DESCRIPTION
The link to Le Guin's Rant on "Technology" was going to some gambling site.  This change instead goes to the Internet Archive's latest capture of it that still points to the original site.