### PR TITLE
Class 4 Toxic Trouble Wayback link

### DIFF
--- a/_classes/04.md
+++ b/_classes/04.md
@@ -65,7 +65,7 @@ Computers allow us to forget about tangible objects, but they are still part of 
 - Ursula K. Le Guin, [A Rant About "Technology"](http://www.ursulakleguinarchive.com/Note-Technology.html)
 - Miriam  Posner, [See No Evil](https://logicmag.io/scale/see-no-evil/), Logic mag, Issue 4 (April 2018)
 - Ingrid Burrington, [Light Industry: Toxic Waste and Pastoral Capitalism](https://www.e-flux.com/journal/74/59781/light-industry-toxic-waste-and-pastoral-capitalism/), e-flux Journal #74 (June 2016)
-- Sharon Begley with John Carey, [Toxic Trouble in Silicon Valley](https://icrt.co/wp-content/uploads/2019/12/1984_5_7-Toxic-Trouble-in-Silicon-Valley-Newsweek.pdf) (May 1984)
+- Sharon Begley with John Carey, [Toxic Trouble in Silicon Valley](https://web.archive.org/web/20230601051943/https://icrt.co/wp-content/uploads/2019/12/1984_5_7-Toxic-Trouble-in-Silicon-Valley-Newsweek.pdf) (May 1984)
 - Lisa Nakamura, [Indigenous Circuits: Navajo Women and the Racialization of Early Electronic Manufacture](https://warwick.ac.uk/fac/arts/english/currentstudents/undergraduate/modules/fulllist/first/en122/lecturelist2019-20/nakamura_indigenous-circuits.pdf) (Dec 2014)
 
 </div>


### PR DESCRIPTION
The link to the PDF file for the Toxic Trouble in Silicon Valley article was giving a 404 error.   This change makes it a link to the Internet Archive's last capture of the PDF.