### PR TITLE
Class 8 picture link change

### DIFF
--- a/_classes/08.md
+++ b/_classes/08.md
@@ -27,7 +27,7 @@ title: Class 8 - Safety // physical and emotional health
 </div>
 
 <div class="img2" markdown="1">
-<span class="imgRef"><a href="https://archive.org/details/BYTE_Vol_15-06_1990-06_Windows_3.0/page/n193/mode/2up"> &#x274B; </a></span>
+<span class="imgRef"><a href="https://archive.org/details/BYTE_Vol_15-06_1990-06_Windows_3.0/page/n241/mode/2up"> &#x274B; </a></span>
 <img src="{{ site.baseurl }}/assets/img/byte15.jpg">
 </div>
 


### PR DESCRIPTION
The link for the picture in class 8 is changed.  It was for a previous picture that was on a different page of the issue of BYTE magazine.  This change is for the page that the picture is from.