### PR TITLE
Class 12 Windows 95 Emulator Link Moved

### DIFF
--- a/_classes/12.md
+++ b/_classes/12.md
@@ -18,7 +18,7 @@ title: Class 12 - Users and their Internet Service Providers
 
 <div class="emulation" markdown="1">
 ## Emulator as koan
-- [Windows 95](https://win95.ajf.me/win95.html)
+- [Windows 95](https://archive.org/details/win95_in_dosbox)
 
 </div>
 


### PR DESCRIPTION
The original owner of that site moved the Win95 emulation to the Internet Archive. This change updates that link.