### PR TITLE
Class 13 History of Search Engines Wayback Link

### DIFF
--- a/_classes/13.md
+++ b/_classes/13.md
@@ -62,7 +62,7 @@ Today, google reigns supreme in search (and search advertising) to the point of 
 <div class="readings" markdown="1">
 ## Readings
 
-- Jon Penland, [The History of Web Search Engines: What Came Before Google?](https://www.whoishostingthis.com/resources/history-search-engines/) (April 2020)
+- Jon Penland, [The History of Web Search Engines: What Came Before Google?](https://web.archive.org/web/20210427195319/https://www.whoishostingthis.com/resources/history-search-engines/) (April 2020)
 - Richard E. Peterson, [Eight Internet search engines compared](https://firstmonday.org/ojs/index.php/fm/article/view/510) (February 1997)
 - Safiya Noble, [Google Has a Striking History of Bias Against Black Girls](https://time.com/5209144/google-search-engine-algorithm-bias-racism/) (March 2018)
 - Rose Martelli, [Getting Smart, the Stupid Web Way](https://web.archive.org/web/19991127091301/http://www.salonmagazine.com/tech/feature/1999/11/03/altavista/index.html) (Nov 1999)


### PR DESCRIPTION
The link for History of Web Search Engines was showing a page that just had "Gone Permanently".  This change gives the link to the last Internet Archive capture of the actual article.