### PR TITLE
Class 14 fix spelling and copy paste

### DIFF
--- a/_classes/14.md
+++ b/_classes/14.md
@@ -8,7 +8,7 @@ title: Class 14 - Browser // Dawn of the mosaic-eating monster
 
 <div class="aperitifs" markdown="1">
 ## Apéritif
-- [The Torjan Room Coffee Machine](https://www.cl.cam.ac.uk/coffee/coffee.html)
+- [The Trojan Room Coffee Machine](https://www.cl.cam.ac.uk/coffee/coffee.html)
 </div>
 
 <div class="rfc" markdown="1">
@@ -27,7 +27,7 @@ title: Class 14 - Browser // Dawn of the mosaic-eating monster
 </div>
 
 <div class="img2" markdown="1">
-<span class="imgRef"><a href="https://archive.org/details/BYTEVolume22Number06/page/n23/mode/2uphttps://archive.org/details/byte-magazine-1995-09/page/n103/mode/2up"> &#x274B; </a></span>
+<span class="imgRef"><a href="https://archive.org/details/byte-magazine-1995-09/page/n103/mode/2up"> &#x274B; </a></span>
 <img src="{{ site.baseurl }}/assets/img/byte6.jpg">
 </div>
 


### PR DESCRIPTION
Fix a spelling error and what looks like a copy paste error on a link.  The updated link confirmed to go to the correct page for the picture.